### PR TITLE
NNEO-13725 Support for Custom Offer Implementation in PHP SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 !.phpunit.cache/.gitkeep
 /report/
 .env_*
+.cursor/

--- a/examples/payment-forms/custom_offer_link.php
+++ b/examples/payment-forms/custom_offer_link.php
@@ -1,0 +1,25 @@
+<?php
+include __DIR__ . '/../../vendor/autoload.php';
+
+$sharedSecret = getenv('VENDO_SHARED_SECRET', true) ?: 'Your_Vendo_Shared_Secret__get_it_from_us';
+$customOfferLink = new \VendoSdk\Url\CustomOffer($sharedSecret);
+$customOfferLink->setSite(20);
+$customOfferLink->setType('normal');
+$customOfferLink->setBillingScheduleType('trial');
+$customOfferLink->setInitialAmount(2.95);
+$customOfferLink->setInitialDuration(3);
+$customOfferLink->setRebillAmount(30);
+$customOfferLink->setRebillDuration(30);
+$customOfferLink->setAffiliateId(0); // zero means organic traffic or search engine traffic
+$customOfferLink->setSuccessUrl('http://google.com');
+$customOfferLink->setDeclineUrl('http://yahoo.com?q=test');
+$customOfferLink->setRef('refxyz_999_www');
+
+// Custom Offer URLs require a signature (use getSignedUrl()). Optional billing_currency also requires signing.
+// $customOfferLink->setBillingCurrency(\VendoSdk\Vendo::CURRENCY_USD);
+
+$url = $customOfferLink->getSignedUrl();
+
+// redirect the user to Vendo's payment page
+// header('Location: ' . $url);
+echo $url . PHP_EOL;

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,8 @@ Example flow:
    - S2S Payment
 
 ## Changelog
+### v2.4.1
+- Added Custom Offer hosted payment link support (`VendoSdk\Url\CustomOffer`) and example at `examples/payment-forms/custom_offer_link.php`
 ### v2.4.0
 - Added billing_currency param to the standard join link
 ### v2.3.0

--- a/src/Url/CustomOffer.php
+++ b/src/Url/CustomOffer.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace VendoSdk\Url;
+
+use VendoSdk\Crypto\Aes128Ecb;
+use VendoSdk\Exception;
+use VendoSdk\Vendo;
+
+/**
+ * Use this class to generate Custom Offer links (on-the-fly billing amounts and schedule via URL parameters).
+ *
+ * Catalog offer parameters are intentionally omitted: use {@see Join} or {@see Oneclick} when passing
+ * `offers`, `selected_offer`, `offer`, or `offers`.
+ *
+ * @see https://docs.vendoservices.com/docs/custom-offer-link
+ *
+ * Custom billing parameters
+ * @method setSite(int $vendoSiteId)
+ * @method int getSite()
+ * @method setType(string $type) normal or oneclick
+ * @method string getType()
+ * @method setBillingScheduleType(string $type) trial, membership, lifetime, or token
+ * @method string getBillingScheduleType()
+ * @method setInitialAmount(float $amount) USD amount for initial price point when applicable
+ * @method float getInitialAmount()
+ * @method setInitialDuration(int $days) Duration in days of the initial period
+ * @method int getInitialDuration()
+ * @method setRebillAmount(float $amount) USD amount for recurring rebills when applicable
+ * @method float getRebillAmount()
+ * @method setRebillDuration(int $days) Days between recurring rebills
+ * @method int getRebillDuration()
+ * @method setTokenAmount(float $amount) USD amount for token pricing when applicable
+ * @method float getTokenAmount()
+ * @method setTokenQuantity(int $quantity) Total quantity of tokens when billing_schedule_type is token
+ * @method int getTokenQuantity()
+ *
+ * Standard Join-style parameters (same path as {@see Join}, excluding catalog offer IDs)
+ * @method setPage(string $page)
+ * @method string getPage()
+ * @method setCountry(string $country)
+ * @method string getCountry()
+ * @method setLanguage(string $language)
+ * @method string getLanguage()
+ * @method setBillingCurrency(string $currency) USD, EUR or GBP. URL must be signed.
+ * @method string getBillingCurrency()
+ * @method setEmail(string $email)
+ * @method string getEmail()
+ * @method setUsername(string $username)
+ * @method string getUsername()
+ * @method setPassword(string $password)
+ * @method string getPassword()
+ * @method setEmailHide(int $hide)
+ * @method int getEmailHide()
+ * @method setUsernameHide(int $hide)
+ * @method int getUsernameHide()
+ * @method setPasswordHide(int $hide)
+ * @method int getPasswordHide()
+ * @method setSubscription(int $subscriptionId) Required context for type=oneclick flows
+ * @method string getSubscription()
+ * @method setFirstname(string $firstname)
+ * @method string getFirstname()
+ * @method setLastname(string $lastname)
+ * @method string getLastname()
+ * @method setStreet(string $street)
+ * @method string getStreet()
+ * @method setCity(string $city)
+ * @method string getCity()
+ * @method setZip(string $zip)
+ * @method string getZip()
+ * @method setState(string $state)
+ * @method string getState()
+ * @method setXsalesMax(int $xsalesMax)
+ * @method int getXsalesMax()
+ * @method setXsales(array $xsalesOfferIds)
+ * @method array getXsales()
+ * @method setXsaleRef(array $xsalesRefs)
+ * @method array getXsaleRef()
+ * @method setSuccessUrl(string $url)
+ * @method string getSuccessUrl()
+ * @method setDeclineUrl(string $url)
+ * @method string getDeclineUrl()
+ * @method setLogindataHide(int $hide)
+ * @method string getLogindataHide()
+ * @method setRef(string $merchantReference)
+ * @method string getRef()
+ * @method setAffiliateId(int $affiliateId)
+ * @method string getAffiliateId()
+ * @method setCampaignId(int $campaignId)
+ * @method int getCampaignId()
+ * @method setProgramId(int $programId)
+ * @method int getProgramId()
+ * @method setSiteName(string $siteName)
+ * @method string getSiteName()
+ * @method setSiteUrl(string $siteUrl)
+ * @method string getSiteUrl()
+ */
+class CustomOffer extends Base
+{
+    public function getBaseUrl(): string
+    {
+        return parent::getBaseUrl() . '/v/custom-offer';
+    }
+
+    /**
+     * @param string $paramName
+     * @param mixed $paramValue
+     * @throws Exception
+     */
+    public function __set(string $paramName, $paramValue): void
+    {
+        if ($paramName === 'password') {
+            $paramValue = Aes128Ecb::encrypt($paramValue, $this->getSharedSecret());
+            parent::__set('password_encrypted', 1);
+        }
+        if ($paramName === 'xsales' || $paramName === 'xsale_ref') {
+            if (is_array($paramValue)) {
+                $paramValue = implode(',', $paramValue);
+            }
+        }
+        parent::__set($paramName, $paramValue);
+    }
+
+    /**
+     * @param string $paramName
+     * @return false|mixed|string[]|null
+     * @throws Exception
+     */
+    public function __get(string $paramName)
+    {
+        $paramValue = parent::__get($paramName);
+        if ($paramName === 'xsales' || $paramName === 'xsale_ref') {
+            if (is_string($paramValue) && $paramValue !== '') {
+                $paramValue = explode(',', $paramValue);
+            }
+        } elseif ($paramName === 'password') {
+            if (!empty($this->urlParamValues[$paramName])) {
+                $paramValue = Aes128Ecb::decrypt($this->urlParamValues[$paramName], $this->getSharedSecret());
+            }
+        }
+        return $paramValue;
+    }
+
+    protected function setUrlParametersValidators(): void
+    {
+        parent::setUrlParametersValidators();
+
+        $this->urlParamValidators['country'] = function ($value) {
+            if (strlen($value) != 2) {
+                throw new Exception('The country parameter must have exactly two characters, example: US.');
+            }
+        };
+        $this->urlParamValidators['page'] = function ($value) {
+            if ($value !== 'join' && $value !== 'prejoin') {
+                throw new Exception('The page parameter must be join or prejoin.');
+            }
+        };
+        $this->urlParamValidators['site_url'] = $this->urlParamValidators['success_url'];
+        $this->urlParamValidators['billing_currency'] = function ($value) {
+            if (!in_array($value, Vendo::getAllowedBillingCurrencies(), true)) {
+                throw new Exception(sprintf(
+                    'billing_currency must be one of: %s.',
+                    implode(', ', Vendo::getAllowedBillingCurrencies())
+                ));
+            }
+        };
+        $this->urlParamValidators['type'] = function ($value) {
+            if (!in_array($value, ['normal', 'oneclick'], true)) {
+                throw new Exception('The type parameter must be normal or oneclick.');
+            }
+        };
+        $this->urlParamValidators['billing_schedule_type'] = function ($value) {
+            if (!in_array($value, ['trial', 'membership', 'lifetime', 'token'], true)) {
+                throw new Exception('billing_schedule_type must be trial, membership, lifetime, or token.');
+            }
+        };
+    }
+
+    protected function setAllowedUrlParameters(): void
+    {
+        $this->allowedUrlParams = [
+            'site',
+            'type',
+            'billing_schedule_type',
+            'initial_amount',
+            'initial_duration',
+            'rebill_amount',
+            'rebill_duration',
+            'token_amount',
+            'token_quantity',
+            'page',
+            'country',
+            'language',
+            'billing_currency',
+            'email',
+            'username',
+            'password',
+            'password_encrypted',
+            'email_hide',
+            'username_hide',
+            'password_hide',
+            'subscription',
+            'firstname',
+            'lastname',
+            'street',
+            'city',
+            'zip',
+            'state',
+            'xsales_max',
+            'xsales',
+            'xsale_ref',
+            'decline_url',
+            'success_url',
+            'logindata_hide',
+            'ref',
+            'affiliate_id',
+            'campaign_id',
+            'program_id',
+            'site_name',
+            'site_url',
+            'expires',
+        ];
+    }
+}

--- a/src/Vendo.php
+++ b/src/Vendo.php
@@ -3,7 +3,7 @@ namespace VendoSdk;
 
 final class Vendo
 {
-    const SDK_VERSION = '2.1.2';
+    const SDK_VERSION = '2.4.1';
 
     const CURRENCY_USD = 'USD';
     const CURRENCY_EUR = 'EUR';

--- a/tests/Url/CustomOfferTest.php
+++ b/tests/Url/CustomOfferTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace VendoSdkUnit\Url;
+
+use VendoSdk\Url\CustomOffer;
+use VendoSdk\Vendo;
+
+class CustomOfferTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetSignedUrl()
+    {
+        $sharedSecret = 'test';
+        $url = new CustomOffer($sharedSecret);
+        $url->setSite(20);
+        $url->setType('normal');
+        $url->setBillingScheduleType('trial');
+        $url->setInitialAmount(2.95);
+        $url->setInitialDuration(3);
+        $url->setRebillAmount(30);
+        $url->setRebillDuration(30);
+
+        $signedUrl = $url->getSignedUrl();
+
+        $this->assertStringContainsString('site=20', $signedUrl);
+        $this->assertStringContainsString('type=normal', $signedUrl);
+        $this->assertStringContainsString('billing_schedule_type=trial', $signedUrl);
+        $this->assertStringContainsString('initial_amount=2.95', $signedUrl);
+        $this->assertStringContainsString('signature=', $signedUrl);
+        $this->assertStringContainsString('sdkv=' . Vendo::SDK_VERSION, $signedUrl);
+    }
+
+    public function testTypeInvalidThrows()
+    {
+        $this->expectException(\VendoSdk\Exception::class);
+        $this->expectExceptionMessage('The type parameter must be normal or oneclick.');
+
+        $url = new CustomOffer('test');
+        $url->setSite(1);
+        $url->setType('invalid');
+    }
+}


### PR DESCRIPTION
This pull request introduces support for generating Custom Offer hosted payment links in the SDK. It adds a new `CustomOffer` class for flexible, on-the-fly billing configuration via URL parameters, provides an example usage script, and includes automated tests to ensure correct behavior. Documentation and versioning have also been updated to reflect these changes.

**Custom Offer Link Support:**

* Added new `CustomOffer` class in `src/Url/CustomOffer.php` to generate custom offer payment links with support for various billing parameters, input validation, and secure password handling.
* Introduced automated tests for `CustomOffer` in `tests/Url/CustomOfferTest.php`, covering signed URL generation and parameter validation.
* Added example usage script at `examples/payment-forms/custom_offer_link.php` demonstrating how to create and use a custom offer link.

**Documentation and Versioning:**

* Updated `readme.md` to document the new feature and reference the example script.
* Bumped SDK version to `2.4.1` in `src/Vendo.php`.